### PR TITLE
Remove result from `read_packet` and `write_packet`

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,9 +19,9 @@ async fn main() -> Result<(), Error> {
         StandardId::new(0x321).expect("Invalid src id")
             )?;
             
-    while let Ok(packet) = socket.read_packet()?.await {
+    while let Ok(packet) = socket.read_packet().await {
         println!("{:?}", packet);
-        let rx = socket.write_packet(packet)?.await;
+        let rx = socket.write_packet(packet).await;
     }
 }
 ```

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -165,14 +165,14 @@ impl IsoTpSocket {
         Ok(IsoTpSocket(AsyncFd::new(sock)?))
     }
 
-    pub fn write_packet<'a>(&'a self, packet: &'a [u8]) -> Result<IsoTpWriteFuture, Error> {
-        Ok(IsoTpWriteFuture {
+    pub fn write_packet<'a>(&'a self, packet: &'a [u8]) -> IsoTpWriteFuture {
+        IsoTpWriteFuture {
             socket: self,
             packet,
-        })
+        }
     }
 
-    pub fn read_packet(&self) -> Result<IsoTpReadFuture, Error> {
-        Ok(IsoTpReadFuture { socket: self })
+    pub fn read_packet(&self) -> IsoTpReadFuture {
+        IsoTpReadFuture { socket: self }
     }
 }


### PR DESCRIPTION
This result was never used (Always was OK return type), and it simplifies the await call for macros like tokio::select